### PR TITLE
remove the python version check (<=3.10)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version='1.5.0',
     packages=find_packages(exclude=['docs', 'tests']),
     install_requires=['requests', 'xmltodict'],
-    python_requires='>=3.7,<=3.10',
+    python_requires='>=3.7',
     py_modules=['namesilo'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
os: Archlinux
python version: 3.10.9 

https://github.com/goranvrbaski/python-namesilo/blob/develop/setup.py#L15
Now this verssion check prevent me to install the newest package(1.4.1).
Please consider remove the version check.